### PR TITLE
Add mongodb extension requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
+        "ext-mongo": "^1.2.12",
         "league/flysystem": "~1.0"
     },
     "require-dev": {


### PR DESCRIPTION
Same as doctrine/mongodb, gridfs exists for these versions.