### PR TITLE
Create index on `filename` field if not exists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 vendor
 bin
 coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,8 @@ php:
 install:
   - travis_retry composer install --no-interaction --prefer-source
 
+before_script:
+  - phpenv config-add php_ext.ini
+
 script:
   - php bin/phpunit

--- a/php_ext.ini
+++ b/php_ext.ini
@@ -1,0 +1,1 @@
+extension = "mongo.so"

--- a/src/GridFSAdapter.php
+++ b/src/GridFSAdapter.php
@@ -218,6 +218,9 @@ class GridFSAdapter extends AbstractAdapter
             } else {
                 $id = $this->client->storeBytes($content, $metadata);
             }
+
+            // Create index on files/filename
+            $this->ensureIndex();
         } catch (MongoGridFSException $e) {
             return false;
         }
@@ -251,5 +254,23 @@ class GridFSAdapter extends AbstractAdapter
         }
 
         return $result;
+    }
+
+    /**
+     * Creates index on filename field
+     */
+    protected function ensureIndex()
+    {
+        $indexes = $this->client->getIndexInfo();
+        foreach($indexes as $index) {
+            if ($index['name'] == 'filename_1') {
+                return;
+            }
+        }
+
+        // Looks like there is not index
+        if (method_exists($this->client, 'createIndex')) {
+            $this->client->createIndex(['filename' => \MongoCollection::ASCENDING]);
+        }
     }
 }


### PR DESCRIPTION
For some reason PHP driver does not create an index on `files` collection for `finename` field. Because of this we have a big bunch of slowlogs like this:

```
2015-09-07T15:39:14.341+0200 I QUERY    [conn16969] query files.invoices.files query: { filename: "21027755/18363972.pdf" } planSummary: COLLSCAN ntoskip:0 nscanned:0 nscannedObjects:1885261 keyUpdates:0 writeConflicts:0 numYields:14728 nreturned:1 reslen:190 locks:{ Global: { acquireCount: { r: 29458 } }, Database: { acquireCount: { r: 14729 } }, Collection: { acquireCount: { r: 14729 } } } 875ms
```

Due to fix this please merge my pull request and create new release version. Thank you

P.S. I created an issue for MongoDb https://jira.mongodb.org/browse/PHP-1482
